### PR TITLE
Add access to MACA data for tennessee

### DIFF
--- a/src/json/extramenumetadata.json
+++ b/src/json/extramenumetadata.json
@@ -35,7 +35,8 @@
             "Colorado",
             "Washington",
             "Georgia",
-            "Michigan"
+            "Michigan",
+            "Tennessee"
         ]
     }
 }


### PR DESCRIPTION
Specifically requested by Shrideep. Note that it's a decent amount of data (a little more than the samples for the other states) and will take a few minutes to download. Please make sure it works and the download looks okay.